### PR TITLE
Maven config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,18 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.9</version>
+        <configuration>
+          <downloadSources>true</downloadSources>
+          <downloadJavadocs>true</downloadJavadocs>
+          <addGroupIdToProjectName>true</addGroupIdToProjectName>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,15 @@
       </plugins>
     </pluginManagement>
     <plugins>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
@@ -71,6 +80,12 @@
           <downloadSources>true</downloadSources>
           <downloadJavadocs>true</downloadJavadocs>
           <addGroupIdToProjectName>true</addGroupIdToProjectName>
+          <classpathContainers>
+            <classpathContainer>
+    org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7
+           </classpathContainer>
+          </classpathContainers>
+
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
The tests fail under JSE 8. These changes ask for source and target compatibility with JSE 7. Also request the eclipse plugin to use the 1.7 runtime if available.

To build without failure from CLI on JSE 8 machine, still need to set JAVA_HOME to the JSE 7 JRE but no need for any manual config in Eclipse.
